### PR TITLE
fix(powershell): Honor profile variables in aa-tools script

### DIFF
--- a/aa-tools.ps1
+++ b/aa-tools.ps1
@@ -22,6 +22,14 @@
 # For persistent use, load these in your $PROFILE script before dot-sourcing this file.
 #$Script:AutomationAccountName = "Automate-contoso"
 #$Script:AutomationResourceGroupName = "AACRG"
+
+# If the script variables are not set, try to initialize them from the calling scope (e.g., $PROFILE)
+if ($null -ne $AutomationAccountName -and -not $Script:AutomationAccountName) {
+    $Script:AutomationAccountName = $AutomationAccountName
+}
+if ($null -ne $AutomationResourceGroupName -and -not $Script:AutomationResourceGroupName) {
+    $Script:AutomationResourceGroupName = $AutomationResourceGroupName
+}
 # --- END CONFIGURATION ---
 
 


### PR DESCRIPTION
The aa-tools.ps1 script was modified to strictly use script-scoped variables (e.g., `$Script:AutomationAccountName`), which prevented it from recognizing variables set in a user's PowerShell profile.

This change adds a small block of code at the beginning of the script to check for the presence of these variables in the parent scope. If they exist, their values are copied to the script-scoped variables. This restores the expected behavior where users can configure the script by setting variables in their `$PROFILE`, without needing to modify the script file directly.